### PR TITLE
Add support for comma at TRNAMT.

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/io/AggregateAttribute.java
+++ b/src/main/java/com/webcohesion/ofx4j/io/AggregateAttribute.java
@@ -167,7 +167,7 @@ public class AggregateAttribute implements Comparable<AggregateAttribute> {
     }
     else if (BigDecimal.class.isAssignableFrom(getAttributeType())) {
       if (value != null) {
-        value = new BigDecimal(value.toString());
+        value = new BigDecimal(value.toString().replace(",", "."));
       }
     }
 


### PR DESCRIPTION
TRNAMT can have comma as said by the OFX specification 2.2, page 93:

Amount: 
	Amounts that do not represent whole numbers (for example, 540.32), must
	include a decimal point or comma to indicate the start of the
	fractional amount.