### PR TITLE
bug-trim-header-values Trim the header values from the oxf file when …

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/io/BaseOFXReader.java
+++ b/src/main/java/com/webcohesion/ofx4j/io/BaseOFXReader.java
@@ -190,6 +190,9 @@ public abstract class BaseOFXReader implements OFXReader {
       if (colonIndex >= 0) {
         String name = line.substring(0, colonIndex);
         String value = line.length() > colonIndex ? line.substring(colonIndex + 1) : "";
+        value = value.replace('"', ' ');
+        value = value.replace('\'', ' ');
+        value = value.trim();
         this.contentHandler.onHeader(name, value);
       }
       line = reader.readLine();


### PR DESCRIPTION
…parsing.

Version 1 of the ofx file was not trimming the values of the header variables and removing single and double quotes.  This changes make the processing of version 1 headers match the processing for version 2.
This was notices when a bank formated the header values as:
OFXHEADER: 100
DATA: OFXSGML
VERSION: 102
SECURITY: NONE
ENCODING: USASCII
CHARSET: 1252
COMPRESSION: NONE
OLDFILEUID: NONE
NEWFILEUID: NONE

Notice the space after the colon.  When this happened the ofx parser had the following error:

java.lang.IllegalArgumentException: No enum constant net.sf.ofx4j.domain.data.ApplicationSecurity. NONE
 at java.lang.Enum.valueOf(Enum.java:238)
 at net.sf.ofx4j.io.DefaultStringConversion.fromString(DefaultStringConversion.java:81)
 at net.sf.ofx4j.io.AggregateStackContentHandler.onHeader(AggregateStackContentHandler.java:50)
 at net.sf.ofx4j.io.BaseOFXReader.processOFXv1Headers(BaseOFXReader.java:193)
 at net.sf.ofx4j.io.BaseOFXReader.parse(BaseOFXReader.java:111)
 at net.sf.ofx4j.io.BaseOFXReader.parse(BaseOFXReader.java:68)
 at net.sf.ofx4j.io.AggregateUnmarshaller.unmarshal(AggregateUnmarshaller.java:44)