### PR TITLE
Correct annotation for ORIGCURRENCY

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/domain/data/common/StatementResponse.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/common/StatementResponse.java
@@ -40,7 +40,7 @@ public abstract class StatementResponse extends ResponseMessage implements Accou
    * @return The currency code.
    * @see java.util.Currency#getCurrencyCode()
    */
-  @Element ( name = "CURDEF", required = true, order = 0 )
+  @Element ( name = "CURDEF", required = true, order = 5 )
   public String getCurrencyCode() {
     return currencyCode;
   }

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/statements/InvestmentStatementResponse.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/statements/InvestmentStatementResponse.java
@@ -64,7 +64,7 @@ public class InvestmentStatementResponse extends StatementResponse {
    *
    * @return the date and time for the statement download
    */
-  @Element( name = "DTASOF", required = true, order = 60)
+  @Element( name = "DTASOF", required = true, order = 0)
   public Date getDateOfStatement() {
     return dateOfStatement;
   }

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/BaseBuyInvestmentTransaction.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/BaseBuyInvestmentTransaction.java
@@ -174,8 +174,8 @@ public abstract class BaseBuyInvestmentTransaction extends BaseInvestmentTransac
    *
    * @return the currency code for the transaction
    */
-  public String getCurrencyCode() {
-    return getBuyInvestment().getCurrencyCode();
+  public OriginalCurrency getCurrencyInfo() {
+    return getBuyInvestment().getCurrencyInfo();
   }
 
   /**

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/BaseSellInvestmentTransaction.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/BaseSellInvestmentTransaction.java
@@ -207,8 +207,8 @@ public abstract class BaseSellInvestmentTransaction extends BaseInvestmentTransa
    *
    * @return the currency code for the transaction.
    */
-  public String getCurrencyCode() {
-    return getSellInvestment().getCurrencyCode();
+  public OriginalCurrency getCurrencyInfo() {
+    return getSellInvestment().getCurrencyInfo();
   }
 
   /**

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/BuyInvestmentTransaction.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/BuyInvestmentTransaction.java
@@ -41,7 +41,7 @@ public class BuyInvestmentTransaction {
   private Double fees;
   private Double load;
   private Double total;
-  private String currencyCode;
+  private OriginalCurrency currencyInfo;
   private OriginalCurrency originalCurrencyInfo;
   private String subAccountSecurity;
   private String subAccountFund;
@@ -281,9 +281,9 @@ public class BuyInvestmentTransaction {
    *
    * @return the currency code for the transaction.
    */
-  @Element( name = "CURRENCY", order = 110)
-  public String getCurrencyCode() {
-    return currencyCode;
+  @ChildAggregate( name = "CURRENCY", order = 110)
+  public OriginalCurrency getCurrencyInfo() {
+    return currencyInfo;
   }
 
   /**
@@ -293,8 +293,8 @@ public class BuyInvestmentTransaction {
    *
    * @param currencyCode the currency code for the transaction.
    */
-  public void setCurrencyCode(String currencyCode) {
-    this.currencyCode = currencyCode;
+  public void setCurrencyInfo(OriginalCurrency currency) {
+    this.currencyInfo = currency;
     this.originalCurrencyInfo = null;
   }
 
@@ -317,7 +317,7 @@ public class BuyInvestmentTransaction {
    */
   public void setOriginalCurrencyInfo(OriginalCurrency originalCurrencyInfo) {
     this.originalCurrencyInfo = originalCurrencyInfo;
-    this.currencyCode = null;
+    this.currencyInfo = null;
   }
 
  /**

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/SellInvestmentTransaction.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/SellInvestmentTransaction.java
@@ -376,7 +376,7 @@ public class SellInvestmentTransaction {
    *
    * @return the original currency info for the transaction
    */
-  @Element( name = "ORIGCURRENCY", order = 120)
+  @ChildAggregate( name = "ORIGCURRENCY", order = 120)
   public OriginalCurrency getOriginalCurrencyInfo() {
     return originalCurrencyInfo;
   }

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/SellInvestmentTransaction.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/transactions/SellInvestmentTransaction.java
@@ -44,7 +44,7 @@ public class SellInvestmentTransaction {
   private Boolean taxExempt;
   private Double total;
   private Double gain;
-  private String currencyCode;
+  private OriginalCurrency currencyInfo;
   private OriginalCurrency originalCurrencyInfo;
   private String subAccountSecurity;
   private String subAccountFund;
@@ -353,9 +353,9 @@ public class SellInvestmentTransaction {
    *
    * @return the currency code for the transaction
    */
-  @Element( name = "CURRENCY", order = 110)
-  public String getCurrencyCode() {
-    return currencyCode;
+  @ChildAggregate( name = "CURRENCY", order = 110)
+  public OriginalCurrency getCurrencyInfo() {
+    return currencyInfo;
   }
 
   /**
@@ -365,8 +365,8 @@ public class SellInvestmentTransaction {
    *
    * @param currencyCode the currency code for the transaction
    */
-  public void setCurrencyCode(String currencyCode) {
-    this.currencyCode = currencyCode;
+  public void setCurrencyInfo(OriginalCurrency currency) {
+    this.currencyInfo = currency;
     this.originalCurrencyInfo = null;
   }
 
@@ -389,7 +389,7 @@ public class SellInvestmentTransaction {
    */
   public void setOriginalCurrencyInfo(OriginalCurrency originalCurrencyInfo) {
     this.originalCurrencyInfo = originalCurrencyInfo;
-    this.currencyCode = null;
+    this.currencyInfo = null;
   }
 
   /**

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/seclist/BaseSecurityInfo.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/seclist/BaseSecurityInfo.java
@@ -16,9 +16,10 @@
 
 package com.webcohesion.ofx4j.domain.data.seclist;
 
-import com.webcohesion.ofx4j.meta.ChildAggregate;
-
 import java.util.Date;
+
+import com.webcohesion.ofx4j.domain.data.investment.transactions.OriginalCurrency;
+import com.webcohesion.ofx4j.meta.ChildAggregate;
 
 /**
  * Base class for info about the various types of securities.
@@ -125,8 +126,8 @@ public class BaseSecurityInfo {
    *
    * @return the overriding currency code or null to mean the default currency
    */
-  public String getCurrencyCode() {
-    return getSecurityInfo().getCurrencyCode();
+  public OriginalCurrency getCurrencyInfo() {
+    return getSecurityInfo().getCurrencyInfo();
   }
 
   /**

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/seclist/SecurityInfo.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/seclist/SecurityInfo.java
@@ -16,11 +16,12 @@
 
 package com.webcohesion.ofx4j.domain.data.seclist;
 
+import java.util.Date;
+
+import com.webcohesion.ofx4j.domain.data.investment.transactions.OriginalCurrency;
 import com.webcohesion.ofx4j.meta.Aggregate;
 import com.webcohesion.ofx4j.meta.ChildAggregate;
 import com.webcohesion.ofx4j.meta.Element;
-
-import java.util.Date;
 
 /**
  * Info about a security.
@@ -37,7 +38,7 @@ public class SecurityInfo {
   private String rating;
   private Double unitPrice;
   private Date marketValueDate;
-  private String currencyCode;
+  private OriginalCurrency currencyInfo;
   private String memo;
 
   /**
@@ -187,9 +188,9 @@ public class SecurityInfo {
    *
    * @return the overriding currency code or null to mean the default currency
    */
-  @Element( name = "CURRENCY", order = 80)
-  public String getCurrencyCode() {
-    return currencyCode;
+  @ChildAggregate( name = "CURRENCY", order = 80)
+  public OriginalCurrency getCurrencyInfo() {
+    return currencyInfo;
   }
 
   /**
@@ -198,8 +199,8 @@ public class SecurityInfo {
    *
    * @param currencyCode the overriding currency code or null to mean the default currency
    */
-  public void setCurrencyCode(String currencyCode) {
-    this.currencyCode = currencyCode;
+  public void setCurrencyInfo(OriginalCurrency currencyInfo) {
+    this.currencyInfo = currencyInfo;
   }
 
   /**

--- a/src/test/java/com/webcohesion/ofx4j/domain/data/investment/transactions/TestSellInvestmentTransaction.java
+++ b/src/test/java/com/webcohesion/ofx4j/domain/data/investment/transactions/TestSellInvestmentTransaction.java
@@ -1,0 +1,54 @@
+package com.webcohesion.ofx4j.domain.data.investment.transactions;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+
+import com.webcohesion.ofx4j.domain.data.seclist.SecurityId;
+import com.webcohesion.ofx4j.io.AggregateMarshaller;
+import com.webcohesion.ofx4j.io.v2.OFXV2Writer;
+
+import junit.framework.TestCase;
+
+public class TestSellInvestmentTransaction extends TestCase {
+
+	public void testMarshallCurrencyInfo() throws IOException {
+		SellInvestmentTransaction strans = new SellInvestmentTransaction();
+
+		OriginalCurrency curr = new OriginalCurrency();
+		curr.setCurrencyCode("USD");
+		curr.setCurrencyRate(1.1);
+		strans.setOriginalCurrencyInfo(curr);
+
+		//TBC
+		strans.setCommission(100.1);
+		
+		SecurityId id = new SecurityId();
+		id.setUniqueId("AB12383948");
+		id.setUniqueIdType("ISIN");
+
+		strans.setSecurityId(id);
+		
+		strans.setUnits(100.);
+		strans.setUnitPrice(100.1);
+		strans.setTotal(9909.9);
+		
+		InvestmentTransaction inv = new InvestmentTransaction();
+		inv.setTransactionId("1");
+		inv.setTradeDate(new Date());
+		inv.setSettlementDate(new Date());
+		inv.setServerId("ABC123");
+		
+		strans.setInvestmentTransaction(inv);
+		
+		StringWriter sw = new StringWriter();
+		AggregateMarshaller marshaller = new AggregateMarshaller();
+		
+		marshaller.marshal(strans, new OFXV2Writer(sw));
+
+
+		String output = sw.toString();
+		assertTrue(output.indexOf("USD") > -1);
+	}
+}


### PR DESCRIPTION
Hi, SellInvestmentTransaction had ORIGCURRENCY incorrectly annotated as an @Element instead of a @ChildAggregate.  Result of this is marshalling as <ORIGCURRENCY>com.webcohesion.ofx4j.domain.data.investment.transactions.OriginalCurrency@402f80f5</ORIGCURRENCY>

Test illustrating issue and fix included.
Thanks!
Iain