### PR TITLE
Correct AccountType Enum OFX converter to handle TRUST

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/accounts/AccountType.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/accounts/AccountType.java
@@ -33,8 +33,8 @@ public enum AccountType {
       return INDIVIDUAL;
     } else if ("JOINT".equals(ofxVal)) {
       return JOINT;
-    } else if ("CORPORATE".equals(ofxVal)) {
-      return CORPORATE;
+    } else if ("TRUST".equals(ofxVal)) {
+      return TRUST;
     } else if ("CORPORATE".equals(ofxVal)) {
       return CORPORATE;
     } else {


### PR DESCRIPTION
Looks like the converter handles `CORPORATE` twice and doesn't handle `TRUST`