### PR TITLE
Dont use BigDecimal constructor since it can lead to unpredictable results

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/domain/data/common/Transaction.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/common/Transaction.java
@@ -143,7 +143,7 @@ public class Transaction {
    * @param amount The transaction amount.
    */
   public void setAmount(Double amount) {
-    this.amount = amount == null ? null : new BigDecimal(amount);
+    this.amount = amount == null ? null : BigDecimal.valueOf(amount);
   }
 
   /**


### PR DESCRIPTION
Per the java-doc:
```
     * The results of this constructor can be somewhat unpredictable.
     * One might assume that writing {@code new BigDecimal(0.1)} in
     * Java creates a {@code BigDecimal} which is exactly equal to
     * 0.1 (an unscaled value of 1, with a scale of 1), but it is
     * actually equal to
     * 0.1000000000000000055511151231257827021181583404541015625.
     * This is because 0.1 cannot be represented exactly as a
     * {@code double} (or, for that matter, as a binary fraction of
     * any finite length).  Thus, the value that is being passed
     * <i>in</i> to the constructor is not exactly equal to 0.1,
     * appearances notwithstanding.
```

Test results:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.329 s
[INFO] Finished at: 2020-02-05T16:24:35-05:00
[INFO] ------------------------------------------------------------------------
```