### PR TITLE
Set lastUpdated when creating account info request

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/client/impl/FinancialInstitutionImpl.java
+++ b/src/main/java/com/webcohesion/ofx4j/client/impl/FinancialInstitutionImpl.java
@@ -324,7 +324,9 @@ public class FinancialInstitutionImpl implements FinancialInstitution {
    * @return The account info request.
    */
   protected AccountInfoRequest createAccountInfoRequest() {
-    return new AccountInfoRequest();
+    AccountInfoRequest accountInfoRequest = new AccountInfoRequest();
+    accountInfoRequest.setLastUpdated(new Date(0));
+    return accountInfoRequest;
   }
 
   /**


### PR DESCRIPTION
This fixes an issue with an exception being thrown when requesting account profiles with `readAccountProfiles` in `FinancialInstitution`. The `lastUpdated` property was never set when creating the account info request ever since #27 was merged.

This was the exception being thrown:
```
Exception in thread "main" com.webcohesion.ofx4j.io.RequiredAttributeException: Required element 'DTACCTUP' (property 'lastUpdated' of aggregate com.webcohesion.ofx4j.domain.data.signup.AccountInfoRequest) is null or empty.
	at com.webcohesion.ofx4j.io.AggregateMarshaller.writeAggregateAttributes(AggregateMarshaller.java:118)
	at com.webcohesion.ofx4j.io.AggregateMarshaller.writeAggregateAttributes(AggregateMarshaller.java:103)
	at com.webcohesion.ofx4j.io.AggregateMarshaller.writeAggregateAttributes(AggregateMarshaller.java:103)
	at com.webcohesion.ofx4j.io.AggregateMarshaller.writeAggregateAttributes(AggregateMarshaller.java:103)
	at com.webcohesion.ofx4j.io.AggregateMarshaller.marshal(AggregateMarshaller.java:59)
	at com.webcohesion.ofx4j.client.net.OFXV1Connection.sendRequest(OFXV1Connection.java:56)
	at com.webcohesion.ofx4j.client.impl.FinancialInstitutionImpl.sendRequest(FinancialInstitutionImpl.java:151)
	at com.webcohesion.ofx4j.client.impl.FinancialInstitutionImpl.readAccountProfiles(FinancialInstitutionImpl.java:92)
	at OfxTestKt.main(OfxTest.kt:19)
	at OfxTestKt.main(OfxTest.kt)
```