### PR TITLE
Write lists annotated by @Element to multiple tags, rather than list form

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/io/AggregateMarshaller.java
+++ b/src/main/java/com/webcohesion/ofx4j/io/AggregateMarshaller.java
@@ -98,16 +98,20 @@ public class AggregateMarshaller {
               if (aggregateAttribute.isCollection()) {
                 attributeName = aggregateInfo.getName();
               }
-              
+
               writer.writeStartAggregate(attributeName);
               writeAggregateAttributes(value, writer, aggregateInfo.getAttributes());
               writer.writeEndAggregate(attributeName);
             }
             break;
           case ELEMENT:
-            String value = getConversion().toString(childValue);
-            if ((value != null) && (!"".equals(value.trim()))) {
-              writer.writeElement(aggregateAttribute.getName(), value);
+            if (childValue instanceof Collection) {
+              //For element lists of children, write them as individual tags.
+              for (Object c : (Collection<?>) childValue) {
+                writeElement(c, writer, aggregateAttribute);
+              }
+            } else {
+              writeElement(childValue, writer, aggregateAttribute);
             }
             break;
           default:
@@ -120,6 +124,12 @@ public class AggregateMarshaller {
     }
   }
 
+  private void writeElement(Object childValue, OFXWriter writer, AggregateAttribute aggregateAttribute) throws IOException {
+    String value = getConversion().toString(childValue);
+    if ((value != null) && (!"".equals(value.trim()))) {
+      writer.writeElement(aggregateAttribute.getName(), value);
+    }
+  }
   /**
    * The conversion.
    *

--- a/src/test/java/com/webcohesion/ofx4j/domain/data/tax1099/TestTax1099R.java
+++ b/src/test/java/com/webcohesion/ofx4j/domain/data/tax1099/TestTax1099R.java
@@ -1,0 +1,45 @@
+package com.webcohesion.ofx4j.domain.data.tax1099;
+
+import com.webcohesion.ofx4j.io.AggregateMarshaller;
+import com.webcohesion.ofx4j.io.v2.OFXV2Writer;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+public class TestTax1099R extends TestCase {
+
+    public void testMarshallMultipleDistributionCodes() throws IOException {
+        Tax1099R tax1099R = new Tax1099R();
+
+        //Required
+        tax1099R.setSrvrtId("test");
+        tax1099R.setTaxYear("2020");
+        tax1099R.setGrossDist("10");
+        tax1099R.setIraSepSimp("N");
+        tax1099R.setPayerId("testing");
+
+        PayerAddress payerAddress = new PayerAddress();
+        payerAddress.setAddress1("testing");
+        payerAddress.setPayerName1("testing");
+        payerAddress.setCity("testing");
+        payerAddress.setState("TEST");
+        payerAddress.setPostalCode("12341");
+        tax1099R.setPayerAddress(payerAddress);
+        tax1099R.setRecId("1234567");
+        tax1099R.setRecAcct("1234567");
+
+        tax1099R.setDistCodes(Arrays.asList("A", "G"));
+
+        StringWriter sw = new StringWriter();
+        AggregateMarshaller marshaller = new AggregateMarshaller();
+
+        marshaller.marshal(tax1099R, new OFXV2Writer(sw));
+
+        String output = sw.toString();
+        assertTrue(output.contains("<DISTCODE>A</DISTCODE>"));
+        assertTrue(output.contains("<DISTCODE>G</DISTCODE>"));
+    }
+}

--- a/src/test/java/com/webcohesion/ofx4j/io/AggregateExample.java
+++ b/src/test/java/com/webcohesion/ofx4j/io/AggregateExample.java
@@ -34,6 +34,7 @@ public class AggregateExample {
   private String element1;
   private AggregateExample2 aggregate1;
   private AggregateExample2 aggregate2;
+  private List<String> elementList;
   private List aggregateList;
 
   @Header ( name = "HEADER1" )
@@ -57,6 +58,15 @@ public class AggregateExample {
   @Element ( name = "SOMEELEMENT", order = 0 )
   public String getElement1() {
     return element1;
+  }
+
+  @Element ( name = "SOMEELEMENTLIST", order = 30 )
+  public List<String> getElementList() {
+    return elementList;
+  }
+
+  public void setElementList(List<String> elementList) {
+    this.elementList = elementList;
   }
 
   public void setElement1(String element1) {

--- a/src/test/java/com/webcohesion/ofx4j/io/TestAggregateMarshaller.java
+++ b/src/test/java/com/webcohesion/ofx4j/io/TestAggregateMarshaller.java
@@ -57,6 +57,7 @@ public class TestAggregateMarshaller extends TestCase {
     child3.setElement("child3-element1");
     AggregateExample3 child4 = new AggregateExample3();
     child4.setElement("child4-element1");
+    example.setElementList(Arrays.asList("root-element-list-1", "root-element-list-2"));
     example.setAggregateList(Arrays.asList(child3, child4));
     new AggregateMarshaller().marshal(example, new OFXWriter() {
       public void writeHeaders(Map<String, String> headers) throws IOException {
@@ -87,8 +88,10 @@ public class TestAggregateMarshaller extends TestCase {
     assertEquals(2, headersWritten.size());
     assertEquals("header1", headersWritten.get("HEADER1"));
     assertEquals("header2", headersWritten.get("ANOTHERHEADER"));
-    assertEquals(5, elementValuesWritten.size());
-    assertEquals("SOMEELEMENT", elementValuesWritten.get("root-element1"));
+    assertEquals(7, elementValuesWritten.size());
+    assertEquals("SOMEELEMENTLIST", elementValuesWritten.get("root-element-list-1"));
+    assertEquals("SOMEELEMENTLIST", elementValuesWritten.get("root-element-list-2"));
+    assertEquals("EXAMPLE3EL1", elementValuesWritten.get("child4-element1"));
     assertEquals("EXAMPLE2EL1", elementValuesWritten.get("child1-element1"));
     assertEquals("EXAMPLE2EL1", elementValuesWritten.get("child2-element1"));
     assertEquals("EXAMPLE2EL1", elementValuesWritten.get("child3-element1"));
@@ -121,6 +124,7 @@ public class TestAggregateMarshaller extends TestCase {
     example.setHeader1("header1");
     example.setHeader2("header2");
     example.setElement1("root-element1");
+    example.setElementList(Arrays.asList("root-element-list-1", "root-element-list-2"));
     AggregateExample2 child1 = new AggregateExample2();
     child1.setElement("child1-element1");
     example.setAggregate1(child1);
@@ -160,6 +164,8 @@ public class TestAggregateMarshaller extends TestCase {
     assertEquals("child2-element1", example.getAggregate2().getElement());
     assertNotNull(example.getAggregateList());
     assertEquals(2, example.getAggregateList().size());
+    assertEquals("root-element-list-1", example.getElementList().get(0));
+    assertEquals("root-element-list-2", example.getElementList().get(1));
     assertEquals("child4-element1", ((AggregateExample3) example.getAggregateList().get(0)).getElement());
     assertEquals("child3-element1", ((AggregateExample4) example.getAggregateList().get(1)).getElement());
   }

--- a/src/test/java/com/webcohesion/ofx4j/io/TestAggregateMetadata.java
+++ b/src/test/java/com/webcohesion/ofx4j/io/TestAggregateMetadata.java
@@ -18,10 +18,12 @@ package com.webcohesion.ofx4j.io;
 
 import junit.framework.TestCase;
 
-import java.util.Map;
-import java.util.Iterator;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
 
 /**
  * @author Ryan Heaton
@@ -47,12 +49,13 @@ public class TestAggregateMetadata extends TestCase {
     AggregateExample2 child3 = new AggregateExample2();
     AggregateExample2 child4 = new AggregateExample2();
     example.setAggregateList(Arrays.asList(child3, child4));
+    example.setElementList(singletonList("evalue1"));
 
     Map<String,Object> headers = info.getHeaders(example);
     assertEquals(2, headers.size());
     assertEquals("3", headers.get("HEADER1"));
     assertEquals("hvalue2", headers.get("ANOTHERHEADER"));
-    assertEquals(4, info.getAttributes().size());
+    assertEquals(5, info.getAttributes().size());
     Iterator<AggregateAttribute> it = info.getAttributes().iterator();
 
     AggregateAttribute elementInfo = it.next();
@@ -94,6 +97,12 @@ public class TestAggregateMetadata extends TestCase {
     assertSame(child2, childAggregate3.get(example));
     childAggregate3.set(child4, example);
     assertSame(child4, example.getAggregate2());
+
+    AggregateAttribute elementListInfo = it.next();
+    assertEquals("SOMEELEMENTLIST", elementListInfo.getName());
+    assertEquals(AggregateAttribute.Type.ELEMENT, elementListInfo.getType());
+    assertEquals(List.class, elementListInfo.getAttributeType());
+    assertEquals(singletonList("evalue1"), elementListInfo.get(example));
 
     assertFalse(it.hasNext());
 


### PR DESCRIPTION
Right now, if you try to unmarshall a list of elements (such as `List<String>`, it will be interpreted as `[ELEMENT1, ELEMENT2]`. This seems to be against how the spec generally works. Examples are [distribution codes for 1099R](https://schemas.liquid-technologies.com/OFX/2.1.1/distcode.html) where it's a basic type, with an unbounded number of elements.

Updated some tests, so feel pretty comfortable with the change, but if we want to talk more through it I'm happy to have that conversation!

Pretty much it can be summed up as I think that:

```
@Element(name = "TESTELEMENT")
List<String> elements;
```

Should be represented as:

```
<TESTELEMENT>test</TESTELEMENT><TESTELEMENT>test 2</TESTELEMENT>
```

vs 

`<TESTELEMENT>[test, test 2]</TESTELEMENT>`

```
Results :

Tests run: 29, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.720 s
[INFO] Finished at: 2021-01-12T14:51:54-05:00
[INFO] ------------------------------------------------------------------------
```