### PR TITLE
Add support for 401(K) loans

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/inv401k/Inv401KInfo.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/inv401k/Inv401KInfo.java
@@ -1,0 +1,286 @@
+package com.webcohesion.ofx4j.domain.data.investment.inv401k;
+
+import com.webcohesion.ofx4j.meta.Aggregate;
+import com.webcohesion.ofx4j.meta.ChildAggregate;
+import com.webcohesion.ofx4j.meta.Element;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Aggregate for the 401(k) account info.
+ *
+ * @see "Section 13.9.3, OFX Spec"
+ */
+@Aggregate("INV401K")
+public class Inv401KInfo {
+
+    private String employerName;
+    private String planId;
+    private Date planJoinDate;
+    private String employerContactInfo;
+    private String brokerContactInfo;
+    private Double preTaxDeferredPercent;
+    private Double afterTaxDeferredPercent;
+    //private MatchInfo matchInfo;
+    //private ContributionsInfo contributionsInfo;
+    private Double estimatedVestedEmployerContributionsPercentage;
+    //private List<VestInfo> vestInfoRecords;
+    private List<LoanInfo> loanInfoRecords;
+    //private Inv401KSummary inv401KSummary;
+
+    /**
+     * Name of the employer. This is a required field according to the OFX spec.
+     *
+     * @return the employer name
+     */
+    @Element(name = "EMPLOYERNAME", required = true, order = 10)
+    public String getEmployerName() {
+        return employerName;
+    }
+
+    /**
+     * Sets the employer name. This is a required field according to the OFX spec.
+     *
+     * @param employerName the name of the employer.
+     */
+    public void setEmployerName(String employerName) {
+        this.employerName = employerName;
+    }
+
+    /**
+     * Plan number. This is not a required field according to the OFX spec.
+     *
+     * @return the plan number
+     */
+    @Element(name = "PLANID", order = 20)
+    public String getPlanId() {
+        return planId;
+    }
+
+    /**
+     * Sets the plan number. This is not a required field according to the OFX spec.
+     *
+     * @param planId the plan number.
+     */
+    public void setPlanId(String planId) {
+        this.planId = employerName;
+    }
+
+    /**
+     * Date the employee joined the plan. This is not a required field according to the OFX spec.
+     *
+     * @return the plan number
+     */
+    @Element(name = "PLANJOINDATE", order = 30)
+    public Date getPlanJoinDate() {
+        return planJoinDate;
+    }
+
+    /**
+     * Sets the date the employee joined the plan. This is not a required field according to the OFX spec.
+     *
+     * @param planJoinDate the date the employee joined the plan.
+     */
+    public void setPlanJoinDate(Date planJoinDate) {
+        this.planJoinDate = planJoinDate;
+    }
+
+    /**
+     * Name of contact person at employer, plus any available contact information, such as phone number. This is not a
+     * required field according to the OFX spec.
+     *
+     * @return the name of contact person at employer, plus any available contact information, such as phone number.
+     */
+    @Element(name = "EMPLOYERCONTACTINFO", order = 40)
+    public String getEmployerContactInfo() {
+        return employerContactInfo;
+    }
+
+    /**
+     * Sets the employer contact info. This is not a required field according to the OFX spec.
+     *
+     * @param employerContactInfo the name of contact person at employer, plus any available contact information, such
+     *                            as phone number.
+     */
+    public void setEmployerContactInfo(String employerContactInfo) {
+        this.employerContactInfo = employerContactInfo;
+    }
+
+    /**
+     * Name of contact person at broker, plus any available contact information, such as phone number. This is not a
+     * required field according to the OFX spec.
+     *
+     * @return the name of contact person at broker, plus any available contact information, such as phone number.
+     */
+    @Element(name = "BROKERCONTACTINFO", order = 50)
+    public String getBrokerContactInfo() {
+        return brokerContactInfo;
+    }
+
+    /**
+     * Sets the broker contact info. This is not a required field according to the OFX spec.
+     *
+     * @param brokerContactInfo the name of contact person at broker, plus any available contact information, such as
+     *                          phone number.
+     */
+    public void setBrokerContactInfo(String brokerContactInfo) {
+        this.brokerContactInfo = brokerContactInfo;
+    }
+
+    /**
+     * Percent of employee salary deferred before tax. This is not a required field according to the OFX spec.
+     *
+     * @return the Percent of employee salary deferred before tax.
+     */
+    @Element(name = "DEFERPCTPRETAX", order = 60)
+    public Double getPreTaxDeferredPercent() {
+        return preTaxDeferredPercent;
+    }
+
+    /**
+     * Sets the percent of employee salary deferred before tax. This is not a required field according to the OFX spec.
+     *
+     * @param preTaxDeferredPercent the percent of employee salary deferred before tax.
+     */
+    public void setPreTaxDeferredPercent(Double preTaxDeferredPercent) {
+        this.preTaxDeferredPercent = preTaxDeferredPercent;
+    }
+
+    /**
+     * Percent of employee salary deferred after tax. This is not a required field according to the OFX spec.
+     *
+     * @return the Percent of employee salary deferred after tax.
+     */
+    @Element(name = "DEFERPCTAFTERTAX", order = 70)
+    public Double getAfterTaxDeferredPercent() {
+        return afterTaxDeferredPercent;
+    }
+
+    /**
+     * Sets the percent of employee salary deferred before tax. This is not a required field according to the OFX spec.
+     *
+     * @param afterTaxDeferredPercent the percent of employee salary deferred after tax.
+     */
+    public void setAfterTaxDeferredPercent(Double afterTaxDeferredPercent) {
+        this.afterTaxDeferredPercent = afterTaxDeferredPercent;
+    }
+
+    ///**
+    // * Employer match information. This is not a required field according to the OFX spec.
+    // *
+    // * @return the employer match information.
+    // */
+    //@ChildAggregate(name = "MATCHINFO", order = 80)
+    //public MatchInfo getMatchInfo() {
+    //    return matchInfo;
+    //}
+
+    ///**
+    // * Sets the employer match information. This is not a required field according to the OFX spec.
+    // *
+    // * @param matchInfo the employer match information.
+    // */
+    //public void setMatchInfo(MatchInfo matchInfo) {
+    //    this.matchInfo = matchInfo;
+    //}
+
+    ///**
+    // * Contributions information. This is not a required field according to the OFX spec.
+    // *
+    // * @return the contributions information.
+    // */
+    //@ChildAggregate(name = "CONTRIBINFO", order = 90)
+    //public ContributionsInfo getContributionsInfo() {
+    //    return contributionsInfo;
+    //}
+
+    ///**
+    // * Sets the contributions information. This is not a required field according to the OFX spec.
+    // *
+    // * @param matchInfo the contributions information.
+    // */
+    //public void setContributionsInfo(ContributionsInfo contributionsInfo) {
+    //    this.contributionsInfo = contributionsInfo;
+    //}
+
+    /**
+     * The estimated percentage of employer contributions vested as of the current date. This is not a required field
+     * according to the OFX spec.
+     *
+     * @return the estimated percentage of employer contributions vested as of the current date.
+     */
+    @Element(name = "CURRENTVESTPCT", order = 100)
+    public Double getEstimatedVestedEmployerContributionsPercentage() {
+        return estimatedVestedEmployerContributionsPercentage;
+    }
+
+    /**
+     * Sets the estimated percentage of employer contributions vested as of the current date. This is not a required
+     * field according to the OFX spec.
+     *
+     * @param estimatedVestedEmployerContributionsPercentage the the estimated percentage of employer contributions
+     *                                                       vested as of the current date.
+     */
+    public void setEstimatedVestedEmployerContributionsPercentage(Double estimatedVestedEmployerContributionsPercentage) {
+        this.estimatedVestedEmployerContributionsPercentage = estimatedVestedEmployerContributionsPercentage;
+    }
+
+    ///**
+    // * Vest change dates. Provides the vesting percentage as of any particular past, current, or future date. This is
+    // * not a required field according to the OFX spec.
+    // *
+    // * @return the vest change dates.
+    // */
+    //@ChildAggregate(name = "VESTINFO", order = 110)
+    //public List<VestInfo> getVestInfoRecords() {
+    //    return vestInfoRecords;
+    //}
+
+    ///**
+    // * Sets the vest change dates. This is not a required field according to the OFX spec.
+    // *
+    // * @param vestInfoRecords the vest change dates.
+    // */
+    //public void setVestInfoRecords(List<VestInfo> vestInfoRecords) {
+    //    this.vestInfoRecords = vestInfoRecords;
+    //}
+
+    /**
+     * Loans outstanding against this account (0 or more). This is not a required field according to the OFX spec.
+     *
+     * @return the loans outstanding against this account.
+     */
+    @ChildAggregate(name = "LOANINFO", order = 120)
+    public List<LoanInfo> getLoanInfoRecords() {
+        return loanInfoRecords;
+    }
+
+    /**
+     * Sets the loans outstanding against this account. This is not a required field according to the OFX spec.
+     *
+     * @param loanInfoRecords the loans outstanding against this account.
+     */
+    public void setLoanInfoRecords(List<LoanInfo> loanInfoRecords) {
+        this.loanInfoRecords = loanInfoRecords;
+    }
+
+    ///**
+    // * List of contributions to 401(k) account. This is not a required field according to the OFX spec.
+    // *
+    // * @return the list of contributions to 401(k) account.
+    // */
+    //@ChildAggregate(name = "INV401KSUMMARY", order = 130)
+    //public Inv401KSummary getInv401KSummary() {
+    //    return inv401KSummary;
+    //}
+
+    ///**
+    // * Sets the list of contributions to 401(k) account. This is not a required field according to the OFX spec.
+    // *
+    // * @param inv401KSummary the list of contributions to 401(k) account.
+    // */
+    //public void setInv401KSummary(Inv401KSummary inv401KSummary) {
+    //    this.inv401KSummary = inv401KSummary;
+    //}
+}

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/inv401k/LoanInfo.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/inv401k/LoanInfo.java
@@ -1,0 +1,325 @@
+package com.webcohesion.ofx4j.domain.data.investment.inv401k;
+
+import com.webcohesion.ofx4j.meta.Aggregate;
+import com.webcohesion.ofx4j.meta.Element;
+
+import java.util.Date;
+
+/**
+ * 401(k) loan information.
+ *
+ * @see "Section 13.9.3, OFX Spec"
+ */
+@Aggregate("LOANINFO")
+public class LoanInfo {
+
+    private String id;
+    private String description;
+    private Double initialLoanBalance;
+    private Date loanStartDate;
+    private Double currentPrincipalBalance;
+    private Date asOfDate;
+    private Double annualInterestRate;
+    private Double paymentAmount;
+    private String paymentFrequency;
+    private Integer initialPayments;
+    private Integer remainingPayments;
+    private Date loanEndDate;
+    private Double projectedInterest;
+    private Double interestPayed;
+    private Date nextPaymentDueDate;
+
+    /**
+     * Identifier of this loan. This is a required field according to the OFX spec.
+     *
+     * @return the identifier of this loan.
+     */
+    @Element(name = "LOANID", required = true, order = 10)
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the identifier of this loan. This is a required field according to the OFX spec.
+     *
+     * @param id the identifier of this loan.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Loan description. This is not a required field according to the OFX spec.
+     *
+     * @return the loan description.
+     */
+    @Element(name = "LOANDESC", order = 20)
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the loan description. This is not a required field according to the OFX spec.
+     *
+     * @param description the loan description.
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Initial loan balance. This is not a required field according to the OFX spec.
+     *
+     * @return the initial loan balance.
+     */
+    @Element(name = "INITIALLOANBAL", order = 30)
+    public Double getInitialLoanBalance() {
+        return initialLoanBalance;
+    }
+
+    /**
+     * Sets the initial loan balance. This is not a required field according to the OFX spec.
+     *
+     * @param initialLoanBalance the initial loan balance.
+     */
+    public void setInitialLoanBalance(Double initialLoanBalance) {
+        this.initialLoanBalance = initialLoanBalance;
+    }
+
+    /**
+     * Start date of loan. This is not a required field according to the OFX spec.
+     *
+     * @return the start date of loan.
+     */
+    @Element(name = "LOANSTARTDATE", order = 40)
+    public Date getLoanStartDate() {
+        return loanStartDate;
+    }
+
+    /**
+     * Sets the start date of loan. This is not a required field according to the OFX spec.
+     *
+     * @param loanStartDate the start date of loan.
+     */
+    public void setLoanStartDate(Date loanStartDate) {
+        this.loanStartDate = loanStartDate;
+    }
+
+    /**
+     * Current loan principal balance. This is a required field according to the OFX spec.
+     *
+     * @return the current loan principal balance.
+     */
+    @Element(name = "CURRENTLOANBAL", required = true, order = 50)
+    public Double getCurrentPrincipalBalance() {
+        return currentPrincipalBalance;
+    }
+
+    /**
+     * Sets the current loan principal balance. This is a required field according to the OFX spec.
+     *
+     * @param currentPrincipalBalance the current loan principal balance.
+     */
+    public void setCurrentPrincipalBalance(Double currentPrincipalBalance) {
+        this.currentPrincipalBalance = currentPrincipalBalance;
+    }
+
+    /**
+     * Date and time of the current loan balance. This is a required field according to the OFX spec.
+     *
+     * @return the date and time of the current loan balance.
+     */
+    @Element(name = "DTASOF", required = true, order = 60)
+    public Date getAsOfDate() {
+        return asOfDate;
+    }
+
+    /**
+     * Sets the date and time of the current loan balance. This is a required field according to the OFX spec.
+     *
+     * @param asOfDate the date and time of the current loan balance.
+     */
+    public void setAsOfDate(Date asOfDate) {
+        this.asOfDate = asOfDate;
+    }
+
+    /**
+     * Loan annual interest rate. This is not a required field according to the OFX spec.
+     *
+     * @return the loan annual interest rate.
+     */
+    @Element(name = "LOANRATE", order = 70)
+    public Double getAnnualInterestRate() {
+        return annualInterestRate;
+    }
+
+    /**
+     * Sets the loan annual interest rate. This is not a required field according to the OFX spec.
+     *
+     * @param annualInterestRate the loan annual interest rate.
+     */
+    public void setAnnualInterestRate(Double annualInterestRate) {
+        this.annualInterestRate = annualInterestRate;
+    }
+
+    /**
+     * Loan payment amount. This is not a required field according to the OFX spec.
+     *
+     * @return the loan payment amount.
+     */
+    @Element(name = "LOANPMTAMT", order = 80)
+    public Double getPaymentAmount() {
+        return paymentAmount;
+    }
+
+    /**
+     * Sets the loan payment amount. This is not a required field according to the OFX spec.
+     *
+     * @param paymentAmount the loan payment amount.
+     */
+    public void setPaymentAmount(Double paymentAmount) {
+        this.paymentAmount = paymentAmount;
+    }
+
+    /**
+     * Frequency of loan repayments. This is not a required field according to the OFX spec.
+     *
+     * @return the frequency of loan repayments.
+     */
+    @Element(name = "LOANPMTFREQ", order = 90)
+    public String getPaymentFrequency() {
+        return paymentFrequency;
+    }
+
+    /**
+     * Sets the frequency of loan repayments. This is not a required field according to the OFX spec.
+     *
+     * @param paymentFrequency the frequency of loan repayments.
+     */
+    public void setPaymentFrequency(String paymentFrequency) {
+        this.paymentFrequency = paymentFrequency;
+    }
+
+    /**
+     * Gets the payment frequency as one of the well-known types.
+     *
+     * @return the payment frequency or null if it's not one of the well-known types
+     */
+    public LoanPaymentFrequency getPaymentFrequencyEnum() {
+        return LoanPaymentFrequency.fromOfx(getPaymentFrequency());
+    }
+
+    /**
+     * Initial number of loan payment. This is not a required field according to the OFX spec.
+     *
+     * @return the initial number of loan payments.
+     */
+    @Element(name = "LOANPMTSINITIAL", order = 100)
+    public Integer getInitialPayments() {
+        return initialPayments;
+    }
+
+    /**
+     * Sets the initial number of loan payments. This is not a required field according to the OFX spec.
+     *
+     * @param initialPayments the initial number of loan payments.
+     */
+    public void setInitialPayments(Integer initialPayments) {
+        this.initialPayments = initialPayments;
+    }
+
+    /**
+     * Remaining number of loan payments.  This is not a required field according to the OFX spec.
+     *
+     * @return the remaining number of loan payments.
+     */
+    @Element(name = "LOANPMTSREMAINING", order = 110)
+    public Integer getRemainingPayments() {
+        return remainingPayments;
+    }
+
+    /**
+     * Sets the remaining number of loan payments. This is not a required field according to the OFX spec.
+     *
+     * @param remainingPayments the remaining number of loan payments.
+     */
+    public void setRemainingPayments(Integer remainingPayments) {
+        this.remainingPayments = remainingPayments;
+    }
+
+    /**
+     * Expected loan end date. This is not a required field according to the OFX spec.
+     *
+     * @return the expected loan end date.
+     */
+    @Element(name = "LOANMATURITYDATE", order = 120)
+    public Date getLoanEndDate() {
+        return loanEndDate;
+    }
+
+    /**
+     * Sets the expected loan end date. This is not a required field according to the OFX spec.
+     *
+     * @param loanEndDate the expected loan end date.
+     */
+    public void setLoanEndDate(Date loanEndDate) {
+        this.loanEndDate = loanEndDate;
+    }
+
+    /**
+     * Total projected interest to be paid on this loan. This is not a required field according to the OFX spec.
+     *
+     * @return the total projected interest to be paid on this loan.
+     */
+    @Element(name = "LOANTOTALPROJINTEREST", order = 130)
+    public Double getProjectedInterest() {
+        return projectedInterest;
+    }
+
+    /**
+     * Sets the total projected interest to be paid on this loan. This is not a required field according to the OFX spec.
+     *
+     * @param projectedInterest the total projected interest to be paid on this loan.
+     */
+    public void setProjectedInterest(Double projectedInterest) {
+        this.projectedInterest = projectedInterest;
+    }
+
+    /**
+     * Total interested paid to date on this loan. This is not a required field according to the OFX spec.
+     *
+     * @return the total interested paid to date on this loan.
+     */
+    @Element(name = "LOANINTERESTTODATE", order = 140)
+    public Double getInterestPayed() {
+        return interestPayed;
+    }
+
+    /**
+     * Sets the total interested paid to date on this loan. This is not a required field according to the OFX spec.
+     *
+     * @param interestPayed the total interested paid to date on this loan.
+     */
+    public void setInterestPayed(Double interestPayed) {
+        this.interestPayed = interestPayed;
+    }
+
+    /**
+     * Next payment due date. This is not a required field according to the OFX spec.
+     *
+     * @return the next payment due date.
+     */
+    @Element(name = "LOANNEXTPMTDATE", order = 150)
+    public Date getNextPaymentDueDate() {
+        return nextPaymentDueDate;
+    }
+
+    /**
+     * Sets the next payment due date. This is not a required field according to the OFX spec.
+     *
+     * @param nextPaymentDueDate the next payment due date.
+     */
+    public void setNextPaymentDueDate(Date nextPaymentDueDate) {
+        this.nextPaymentDueDate = nextPaymentDueDate;
+    }
+}

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/inv401k/LoanPaymentFrequency.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/inv401k/LoanPaymentFrequency.java
@@ -1,0 +1,40 @@
+package com.webcohesion.ofx4j.domain.data.investment.inv401k;
+
+public enum LoanPaymentFrequency {
+    WEEKLY,
+    BIWEEKLY,
+    TWICEMONTHLY,
+    MONTHLY,
+    FOURWEEKS,
+    BIMONTHLY,
+    QUARTERLY,
+    SEMIANNUALLY,
+    ANNUALLY,
+    OTHER;
+
+    public static LoanPaymentFrequency fromOfx(String ofxVal) {
+        if ("WEEKLY".equals(ofxVal)) {
+            return WEEKLY;
+        } else if ("BIWEEKLY".equals(ofxVal)) {
+            return BIWEEKLY;
+        } else if ("TWICEMONTHLY".equals(ofxVal)) {
+            return TWICEMONTHLY;
+        } else  if ("MONTHLY".equals(ofxVal)) {
+            return MONTHLY;
+        } else if ("FOURWEEKS".equals(ofxVal)) {
+            return FOURWEEKS;
+        } else if ("BIMONTHLY".equals(ofxVal)) {
+            return BIMONTHLY;
+        } else if ("QUARTERLY".equals(ofxVal)) {
+            return QUARTERLY;
+        } else if ("SEMIANNUALLY".equals(ofxVal)) {
+            return SEMIANNUALLY;
+        } else if ("ANNUALLY".equals(ofxVal)) {
+            return ANNUALLY;
+        } else if ("OTHER".equals(ofxVal)) {
+            return OTHER;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/webcohesion/ofx4j/domain/data/investment/statements/InvestmentStatementResponse.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/investment/statements/InvestmentStatementResponse.java
@@ -18,6 +18,7 @@ package com.webcohesion.ofx4j.domain.data.investment.statements;
 
 import com.webcohesion.ofx4j.domain.data.common.StatementResponse;
 import com.webcohesion.ofx4j.domain.data.investment.accounts.InvestmentAccountDetails;
+import com.webcohesion.ofx4j.domain.data.investment.inv401k.Inv401KInfo;
 import com.webcohesion.ofx4j.domain.data.investment.positions.InvestmentPositionList;
 import com.webcohesion.ofx4j.domain.data.seclist.SecurityList;
 import com.webcohesion.ofx4j.domain.data.investment.transactions.InvestmentTransactionList;
@@ -42,6 +43,7 @@ public class InvestmentStatementResponse extends StatementResponse {
   private InvestmentPositionList positionList;
   private InvestmentBalance accountBalance;
   private FourOhOneKBalance fourOhOneKBalance;
+  private Inv401KInfo inv401KInfo;
 
   // This is not actually technically part of the INVSTMTRS, but according to Section 13.8.4,
   // OFX spec, this aggregate can appear in a statement response as part of the SECLISTMSGSRQV1
@@ -173,6 +175,25 @@ public class InvestmentStatementResponse extends StatementResponse {
    */
   public void setFourOhOneKBalance(FourOhOneKBalance fourOhOneKBalance) {
     this.fourOhOneKBalance = fourOhOneKBalance;
+  }
+
+  /**
+   * Gets the 401(k) account info. This is an optional field according to the OFX spec.
+   *
+   * @return the 401(k) account info
+   */
+  @ChildAggregate ( order = 110 )
+  public Inv401KInfo getInv401KInfo() {
+    return inv401KInfo;
+  }
+
+  /**
+   * Sets the 401(k) account balance. This is an optional field according to the OFX spec.
+   *
+   * @param inv401KInfo the 401(k) account info
+   */
+  public void setInv401KInfo(Inv401KInfo inv401KInfo) {
+    this.inv401KInfo = inv401KInfo;
   }
 
   /**


### PR DESCRIPTION
#58 
I added partial support for INV401K because the LOANINFO is under it.
I added the aggregates under INV401K that I didn't implement as commented out code.