### PR TITLE
Adding support to read ACCESSTOKEN from OFX request

### DIFF
--- a/src/main/java/com/webcohesion/ofx4j/domain/data/signon/SignonRequest.java
+++ b/src/main/java/com/webcohesion/ofx4j/domain/data/signon/SignonRequest.java
@@ -53,6 +53,7 @@ public class SignonRequest extends RequestMessage {
   private String additionalCredentials2;
   private String authToken;
   private String accessKey;
+  private String accessToken;
 
   /**
    * The date and time of the request.
@@ -338,6 +339,25 @@ public class SignonRequest extends RequestMessage {
    */
   public void setAccessKey(String accessKey) {
     this.accessKey = accessKey;
+  }
+
+  /**
+   * The access key.
+   *
+   * @param accessToken The access key.
+   */
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  /**
+   * The access key.
+   *
+   * @return The access key.
+   */
+  @Element ( name = "ACCESSTOKEN", order = 150 )
+  public String getAccessToken() {
+    return accessToken;
   }
 
   //todo: MFA challenge stuff.


### PR DESCRIPTION
This adds support to read the **ACCESSTOKEN** in the OFX payload

# Background

Per the [OFX Specification v2.3](https://financialdataexchange.org/common/Uploaded%20files/OFX%20files/OFX%20Banking%20Specification%20v2.3.pdf)

> 2.5.1.2.3 <**ACCESSTOKEN**>
Servers may require the use of an <**ACCESSTOKEN**> in place of <USERID> and <USERPASS> for authentication. The server can specify this requirement using the <**ACCESSTOKENREQ**> tag in the applicable <SIGNONINFO> section of the profile response. The use and format of <**ACCESSTOKEN**> must be arranged out-of-band between the client and the OFX Server provider.
Keeping the specific use and format of <**ACCESSTOKEN**> out of band allows OFX to support numerous methods of token generation such as OAUTH 1.0, OAUTH 2.0, JSON Tokens, and so on. Essentially any agreed upon token format and methodology may be used between the client and server.
The intent of <ACCESSTOKEN> is to leverage an out of band mechanism which will fully replace all other types of authentication within OFX for all types of accounts and requests. As such, <**ACCESSTOKEN**> interaction with other <SONRQ> mechanisms and features should be avoided. Of particular note:
• While it would be permissible under the specification to have multiple signon realms with a mixture of <**ACCESSTOKEN**> and <USERID>/<USERPASS> used between those realms this is STRONGLY DISCOURAGED due to the client side complexity which would be created.
• While it would be permissible under the specification to use other OFX MFA mechanisms or requests (such as <CHALLENGERQ>) this is STRONGLY DISCOURAGED due to the client side complexity which would be created.
• When <ACCESSTOKEN> is required by a server and indicated within the signon realm, servers should set <PINCH> and <CHGPINFIRST> to N to indicate that OFX pin change functionality is not supported. All other pin characteristics should be set to some default value as they are not used with this authentication method. Additionally servers should NEVER use <CODE>15000 to request a client side pin change. Lastly, clients should NEVER, even if a server indicates that pin change is supported, send a <PINCHRQ> message to a signon realm on a server whose profile indicates that <ACCESSTOKEN> is required.

## Example OFX Request
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<?OFX OFXHEADER="200" VERSION="220" SECURITY="NONE" OLDFILEUID="NONE"
NEWFILEUID="NONE"?>
<OFX>
<SIGNONMSGSRQV1>
<SONRQ>
<DTCLIENT>20220615214935</DTCLIENT>
<ACCESSTOKEN>S1-A1N1ITIZEDSANI1TI1Z1EDSAN11I-TIZE1DSAN1ITIZEDS
1AN1ITIZ1111EDS1ANITIZEDS1-</ACCESSTOKEN>
<LANGUAGE>ENG</LANGUAGE>
<APPID>TTWeb</APPID>
<APPVER>2021</APPVER>
<APPKEY>SA1NI1TIZE1D11SANIT11IZE1DSANITI</APPKEY>
</SONRQ>
</SIGNONMSGSRQV1>
<TAX1099MSGSRQV1>
<TAX1099TRNRQ>
<TRNUID>ef185e79-436b-4638-87b1-6b1a0e1fe57e</TRNUID>
<TAX1099RQ>
<TAXYEAR>2021</TAXYEAR>
</TAX1099RQ>
</TAX1099TRNRQ>
</TAX1099MSGSRQV1>
</OFX>
```

# Usage

```java
String accessToken = signOnRequestMessageSet.getSignonRequest().getAccessToken();
```